### PR TITLE
change / operator behaviour

### DIFF
--- a/numhstore.control
+++ b/numhstore.control
@@ -1,5 +1,5 @@
 # numhstore extension
 comment = 'Extents hstore with inthstore and floathstore'
-default_version = '0.1'
+default_version = '0.1.1'
 relocatable = true
 requires = 'hstore'

--- a/sql/numhstore--0.1--0.1.1.sql
+++ b/sql/numhstore--0.1--0.1.1.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION hstore_div(a floathstore, b floathstore) RETURNS floathstore AS $$
+DECLARE
+  key_match boolean;
+  missing_keys text[];
+BEGIN  
+  SELECT akeys(a) <@ akeys(b) INTO key_match;
+  IF NOT key_match THEN
+    
+    SELECT array_agg(l) 
+    FROM  skeys(a) l
+    FULL OUTER JOIN skeys(b) r ON l = r 
+    WHERE r IS NULL 
+    INTO missing_keys;
+    
+    RAISE EXCEPTION USING
+      message = 'Keys of the numerator doesn''t match denominator.',
+      detail  = 'extra keys are ' || missing_keys::text,
+      hint    = 'You may want to slice before';
+  END IF;
+
+RETURN
+  COALESCE (hstore(
+    array_agg(key),
+    array_agg((l.value::decimal / r.value::decimal)::text)
+  ),''::hstore)
+  FROM each(a) l
+  RIGHT JOIN each(b) r
+  USING (key);
+END
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT;

--- a/sql/numhstore.sql
+++ b/sql/numhstore.sql
@@ -213,14 +213,32 @@ CREATE OPERATOR / (
 -- Select hstore_div('foo=>10, bar => 15'::hstore, 'foo=>5, bar => 3'::hstore)
 -- =>  "bar"=>"5", "foo"=>"2"
 CREATE FUNCTION hstore_div(a floathstore, b floathstore) RETURNS floathstore AS $$
-BEGIN
+DECLARE
+  key_match boolean;
+  missing_keys text[];
+BEGIN  
+  SELECT akeys(a) <@ akeys(b) INTO key_match;
+  IF NOT key_match THEN
+    
+    SELECT array_agg(l) 
+    FROM  skeys(a) l
+    FULL OUTER JOIN skeys(b) r ON l = r 
+    WHERE r IS NULL 
+    INTO missing_keys;
+    
+    RAISE EXCEPTION USING
+      message = 'Keys of the numerator doesn''t match denominator.',
+      detail  = 'extra keys are ' || missing_keys::text,
+      hint    = 'You may want to slice before';
+  END IF;
+
 RETURN
   COALESCE (hstore(
     array_agg(key),
-    array_agg((COALESCE(l.value::decimal,0) / NULLIF(r.value::decimal,0))::text)
+    array_agg((l.value::decimal / r.value::decimal)::text)
   ),''::hstore)
   FROM each(a) l
-  FULL OUTER JOIN each(b) r
+  RIGHT JOIN each(b) r
   USING (key);
 END
 $$ LANGUAGE 'plpgsql' IMMUTABLE STRICT;

--- a/test/expected/numhstore_operators.out
+++ b/test/expected/numhstore_operators.out
@@ -1,0 +1,184 @@
+SELECT 'a=>3, b=>2'::inthstore + 'a=>2, c=>5'::inthstore;
+           ?column?           
+------------------------------
+ "a"=>"5", "b"=>"2", "c"=>"5"
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore - 'a=>2, c=>5'::inthstore;
+           ?column?            
+-------------------------------
+ "a"=>"1", "b"=>"2", "c"=>"-5"
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore * 'a=>2, c=>5'::inthstore;
+            ?column?            
+--------------------------------
+ "a"=>"6", "b"=>NULL, "c"=>NULL
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore / 'a=>2, b=>5'::inthstore;
+                         ?column?                         
+----------------------------------------------------------
+ "a"=>"1.5000000000000000", "b"=>"0.40000000000000000000"
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore / 'a=>2, b=>2, c=>5'::inthstore;
+                              ?column?                               
+---------------------------------------------------------------------
+ "a"=>"1.5000000000000000", "b"=>"1.00000000000000000000", "c"=>NULL
+(1 row)
+
+SELECT 'a=>3, b=>2, c=>5'::inthstore / 'a=>2, b=>2'::inthstore;
+ERROR:  Keys of the numerator doesn't match denominator.
+DETAIL:  extra keys are {c}
+HINT:  You may want to slice before
+SELECT 'a=>3, b=>2'::floathstore + 'a=>2, c=>5'::floathstore;
+           ?column?           
+------------------------------
+ "a"=>"5", "b"=>"2", "c"=>"5"
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore - 'a=>2, c=>5'::floathstore;
+           ?column?            
+-------------------------------
+ "a"=>"1", "b"=>"2", "c"=>"-5"
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore * 'a=>2, c=>5'::floathstore;
+            ?column?            
+--------------------------------
+ "a"=>"6", "b"=>NULL, "c"=>NULL
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore / 'a=>2, b=>5'::floathstore;
+                         ?column?                         
+----------------------------------------------------------
+ "a"=>"1.5000000000000000", "b"=>"0.40000000000000000000"
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore / 'a=>2, b=>2, c=>5'::floathstore;
+                              ?column?                               
+---------------------------------------------------------------------
+ "a"=>"1.5000000000000000", "b"=>"1.00000000000000000000", "c"=>NULL
+(1 row)
+
+SELECT 'a=>3, b=>2, c=>5'::floathstore / 'a=>2, b=>2'::floathstore;
+ERROR:  Keys of the numerator doesn't match denominator.
+DETAIL:  extra keys are {c}
+HINT:  You may want to slice before
+SELECT 'a=>3, b=>2'::floathstore + 'a=>2, c=>5'::inthstore;
+           ?column?           
+------------------------------
+ "a"=>"5", "b"=>"2", "c"=>"5"
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore - 'a=>2, c=>5'::inthstore;
+           ?column?            
+-------------------------------
+ "a"=>"1", "b"=>"2", "c"=>"-5"
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore * 'a=>2, c=>5'::inthstore;
+            ?column?            
+--------------------------------
+ "a"=>"6", "b"=>NULL, "c"=>NULL
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore / 'a=>2, b=>5'::inthstore;
+                         ?column?                         
+----------------------------------------------------------
+ "a"=>"1.5000000000000000", "b"=>"0.40000000000000000000"
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore / 'a=>2, b=>2, c=>5'::inthstore;
+                              ?column?                               
+---------------------------------------------------------------------
+ "a"=>"1.5000000000000000", "b"=>"1.00000000000000000000", "c"=>NULL
+(1 row)
+
+SELECT 'a=>3, b=>2, c=>5'::floathstore / 'a=>2, b=>2'::inthstore;
+ERROR:  Keys of the numerator doesn't match denominator.
+DETAIL:  extra keys are {c}
+HINT:  You may want to slice before
+SELECT 'a=>3, b=>2'::inthstore + 'a=>2, c=>5'::floathstore;
+           ?column?           
+------------------------------
+ "a"=>"5", "b"=>"2", "c"=>"5"
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore - 'a=>2, c=>5'::floathstore;
+           ?column?            
+-------------------------------
+ "a"=>"1", "b"=>"2", "c"=>"-5"
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore * 'a=>2, c=>5'::floathstore;
+            ?column?            
+--------------------------------
+ "a"=>"6", "b"=>NULL, "c"=>NULL
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore / 'a=>2, b=>5'::floathstore;
+                         ?column?                         
+----------------------------------------------------------
+ "a"=>"1.5000000000000000", "b"=>"0.40000000000000000000"
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore / 'a=>2, b=>2, c=>5'::floathstore;
+                              ?column?                               
+---------------------------------------------------------------------
+ "a"=>"1.5000000000000000", "b"=>"1.00000000000000000000", "c"=>NULL
+(1 row)
+
+SELECT 'a=>3, b=>2, c=>5'::inthstore / 'a=>2, b=>2'::floathstore;
+ERROR:  Keys of the numerator doesn't match denominator.
+DETAIL:  extra keys are {c}
+HINT:  You may want to slice before
+SELECT 'a=>3, b=>2'::inthstore + 3;
+      ?column?      
+--------------------
+ "a"=>"6", "b"=>"5"
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore - 3;
+      ?column?       
+---------------------
+ "a"=>"0", "b"=>"-1"
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore * 3;
+      ?column?      
+--------------------
+ "a"=>"9", "b"=>"6"
+(1 row)
+
+SELECT 'a=>3, b=>2'::inthstore / 3;
+                           ?column?                           
+--------------------------------------------------------------
+ "a"=>"1.00000000000000000000", "b"=>"0.66666666666666666667"
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore + 3;
+      ?column?      
+--------------------
+ "a"=>"6", "b"=>"5"
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore - 3;
+      ?column?       
+---------------------
+ "a"=>"0", "b"=>"-1"
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore * 3;
+      ?column?      
+--------------------
+ "a"=>"9", "b"=>"6"
+(1 row)
+
+SELECT 'a=>3, b=>2'::floathstore / 3;
+                           ?column?                           
+--------------------------------------------------------------
+ "a"=>"1.00000000000000000000", "b"=>"0.66666666666666666667"
+(1 row)
+

--- a/test/sql/numhstore_operators.sql
+++ b/test/sql/numhstore_operators.sql
@@ -1,0 +1,38 @@
+SELECT 'a=>3, b=>2'::inthstore + 'a=>2, c=>5'::inthstore;
+SELECT 'a=>3, b=>2'::inthstore - 'a=>2, c=>5'::inthstore;
+SELECT 'a=>3, b=>2'::inthstore * 'a=>2, c=>5'::inthstore;
+SELECT 'a=>3, b=>2'::inthstore / 'a=>2, b=>5'::inthstore;
+SELECT 'a=>3, b=>2'::inthstore / 'a=>2, b=>2, c=>5'::inthstore;
+SELECT 'a=>3, b=>2, c=>5'::inthstore / 'a=>2, b=>2'::inthstore;
+
+SELECT 'a=>3, b=>2'::floathstore + 'a=>2, c=>5'::floathstore;
+SELECT 'a=>3, b=>2'::floathstore - 'a=>2, c=>5'::floathstore;
+SELECT 'a=>3, b=>2'::floathstore * 'a=>2, c=>5'::floathstore;
+SELECT 'a=>3, b=>2'::floathstore / 'a=>2, b=>5'::floathstore;
+SELECT 'a=>3, b=>2'::floathstore / 'a=>2, b=>2, c=>5'::floathstore;
+SELECT 'a=>3, b=>2, c=>5'::floathstore / 'a=>2, b=>2'::floathstore;
+
+SELECT 'a=>3, b=>2'::floathstore + 'a=>2, c=>5'::inthstore;
+SELECT 'a=>3, b=>2'::floathstore - 'a=>2, c=>5'::inthstore;
+SELECT 'a=>3, b=>2'::floathstore * 'a=>2, c=>5'::inthstore;
+SELECT 'a=>3, b=>2'::floathstore / 'a=>2, b=>5'::inthstore;
+SELECT 'a=>3, b=>2'::floathstore / 'a=>2, b=>2, c=>5'::inthstore;
+SELECT 'a=>3, b=>2, c=>5'::floathstore / 'a=>2, b=>2'::inthstore;
+
+SELECT 'a=>3, b=>2'::inthstore + 'a=>2, c=>5'::floathstore;
+SELECT 'a=>3, b=>2'::inthstore - 'a=>2, c=>5'::floathstore;
+SELECT 'a=>3, b=>2'::inthstore * 'a=>2, c=>5'::floathstore;
+SELECT 'a=>3, b=>2'::inthstore / 'a=>2, b=>5'::floathstore;
+SELECT 'a=>3, b=>2'::inthstore / 'a=>2, b=>2, c=>5'::floathstore;
+SELECT 'a=>3, b=>2, c=>5'::inthstore / 'a=>2, b=>2'::floathstore;
+
+
+SELECT 'a=>3, b=>2'::inthstore + 3;
+SELECT 'a=>3, b=>2'::inthstore - 3;
+SELECT 'a=>3, b=>2'::inthstore * 3;
+SELECT 'a=>3, b=>2'::inthstore / 3;
+
+SELECT 'a=>3, b=>2'::floathstore + 3;
+SELECT 'a=>3, b=>2'::floathstore - 3;
+SELECT 'a=>3, b=>2'::floathstore * 3;
+SELECT 'a=>3, b=>2'::floathstore / 3;


### PR DESCRIPTION
this changes hstore division 

``` SQL
SELECT 'a=>3, b=>2'::inthstore / 'a=>2, b=>5'::inthstore;
                         ?column?                         
----------------------------------------------------------
 "a"=>"1.5000000000000000", "b"=>"0.40000000000000000000"
(1 row)

SELECT 'a=>3, b=>2'::inthstore / 'a=>2, b=>2, c=>5'::inthstore;
                              ?column?                               
---------------------------------------------------------------------
 "a"=>"1.5000000000000000", "b"=>"1.00000000000000000000", "c"=>NULL
(1 row)

SELECT 'a=>3, b=>2, c=>5'::inthstore / 'a=>2, b=>2'::inthstore;
ERROR:  Keys of the numerator doesn't match denominator.
DETAIL:  extra keys are {c}
HINT:  You may want to slice before
```
