### PR TITLE
fixed possible segfault

### DIFF
--- a/src/hstore_array.c
+++ b/src/hstore_array.c
@@ -85,7 +85,7 @@ Datum array_to_hstore(Datum *data, int count, bool *nulls)
         char *num_str;
         int local = i+1;
         if (i < a.used - 1) {
-            while (HAArray_cmp(&a.entry[i], &a.entry[local]) == 0)
+            while (local < a.used && HAArray_cmp(&a.entry[i], &a.entry[local]) == 0)
             {
                 a.entry[i].val += a.entry[local++].val;
                 skip = true;


### PR DESCRIPTION
If the data has a specific structure, it is possible to run over the bounds of the array and cause a segmentation fault.
