### PR TITLE
cibuild: drop sudo for new jenkins

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -1,2 +1,12 @@
 #!/bin/bash
-sudo make clean && sudo make && sudo make install && sudo make installcheck
+
+sudo=''
+case "${HOSTNAME}" in
+vm*)
+    ;;
+*)
+    sudo='sudo'
+    ;;
+esac
+
+$sudo make clean && $sudo make && $sudo make install && $sudo make installcheck


### PR DESCRIPTION
jenkins user on new jenkins may install postgresql extensions w/o sudo.
Drop the sudo prefix on new jenkins keeping compat. with old jenkins.

Note this is not urgent because we have a sed on the new jenkins which takes
care of this.

Note new jenkins uses pg_tmp which runs a new temporary database server for
each test. The PGPORT environment variable points to the currently running
postgresql server. Currently we run tests for postgresql slots 9.4, 9.5 and 9.6
and tests fail for 9.6 only, see:
https://jenkins-1.adjust.com/job/pg-numhstore-445b0a602c2b/10/console